### PR TITLE
[TASK] Add missing composer dependency `psr/log`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
 	"require": {
 		"ext-curl": "*",
 		"php": "^8.0 || ^8.1 || ^8.2",
-		"typo3/cms-core": "11.5.*"
+		"typo3/cms-core": "11.5.*",
+		"psr/log": "^1.0"
 	},
 	"require-dev": {
 		"typo3/cms-backend": "^11.5",


### PR DESCRIPTION
The `sudhaus7-wizard` extensions deals directly with the
PSR-3 `\Psr\Log\LoggerInterface` but misses to list it
as composer dependency. TYPO3 core already requires this
psr interface package, but it's considerable good practice
that every package declare there directly used dependencies.

This change adds the corresponding dependency declaration
to the composer.json.

Used command(s):

```shell
composer require \
    "psr/log":"^1.0"
```

Resolves: #7
