### PR TITLE
[TASK] Make the `CreateProcess` factory based on a interface

### DIFF
--- a/Classes/Cli/RunCommand.php
+++ b/Classes/Cli/RunCommand.php
@@ -17,7 +17,7 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Exception;
 use SUDHAUS7\Sudhaus7Wizard\Domain\Model\Creator;
 use SUDHAUS7\Sudhaus7Wizard\Domain\Repository\CreatorRepository;
-use SUDHAUS7\Sudhaus7Wizard\Services\CreateProcessFactory;
+use SUDHAUS7\Sudhaus7Wizard\Services\CreateProcessFactoryInterface;
 use SUDHAUS7\Sudhaus7Wizard\Tools;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -37,6 +37,13 @@ final class RunCommand extends Command
 {
     public ?ConsoleLogger $logger = null;
     private ?CreatorRepository $repository = null;
+    private CreateProcessFactoryInterface $createProcessFactory;
+
+    public function __construct(CreateProcessFactoryInterface $createProcessFactory)
+    {
+        parent::__construct();
+        $this->createProcessFactory = $createProcessFactory;
+    }
 
     protected function configure(): void
     {
@@ -76,9 +83,8 @@ final class RunCommand extends Command
                     if ($o instanceof Creator) {
                         $this->getInfo($o, $input, $output);
                         return Command::SUCCESS;
-                    } else {
-                        $output->writeln('<info>Not found</info>');
                     }
+                    $output->writeln('<info>Not found</info>');
                 } else {
                     $o = $this->repository->findNext();
                     if ($o instanceof Creator) {
@@ -161,7 +167,7 @@ final class RunCommand extends Command
         //$output->write(implode("\n",)."\n");
 
         try {
-            if (CreateProcessFactory::get($creator, $this->logger)->run($mapfolder)) {
+            if ($this->createProcessFactory->get($creator, $this->logger)->run($mapfolder)) {
                 $output->write("Fertig\n", true);
                 $creator->setStatus(20);
 

--- a/Classes/Domain/Model/Creator.php
+++ b/Classes/Domain/Model/Creator.php
@@ -17,12 +17,12 @@ namespace SUDHAUS7\Sudhaus7Wizard\Domain\Model;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use function str_starts_with;
 use SUDHAUS7\Sudhaus7Wizard\Tools;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Configuration\Loader\YamlFileLoader;
 use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use function str_starts_with;
 
 /**
  * Model Creator
@@ -61,7 +61,8 @@ class Creator implements LoggerAwareInterface
         protected int $sourcefilemount,
         protected string $sourceclass,
         private array $valuemappingcache = []
-    ) {}
+    ) {
+    }
 
     /**
      * @param array{
@@ -114,7 +115,7 @@ class Creator implements LoggerAwareInterface
 
     public function getSourcepid(): int
     {
-        if ( str_starts_with((string)$this->sourcepid, 't3://')) {
+        if (str_starts_with((string)$this->sourcepid, 't3://')) {
             return (int)GeneralUtility::trimExplode('=', $this->sourcepid)[1];
         }
         return (int)$this->sourcepid;
@@ -364,5 +365,4 @@ class Creator implements LoggerAwareInterface
         $this->redpass = $redpass;
         return $this;
     }
-
 }

--- a/Classes/Services/AbstractCreateProcessFactory.php
+++ b/Classes/Services/AbstractCreateProcessFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * @author Frank Berger <fberger@sudhaus7.de>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SUDHAUS7\Sudhaus7Wizard\Services;
+
+use Psr\Log\LoggerInterface;
+use SUDHAUS7\Sudhaus7Wizard\CreateProcess;
+use SUDHAUS7\Sudhaus7Wizard\Domain\Model\Creator;
+use SUDHAUS7\Sudhaus7Wizard\Interfaces\WizardProcessInterface;
+use SUDHAUS7\Sudhaus7Wizard\Sources\LocalDatabase;
+use SUDHAUS7\Sudhaus7Wizard\Sources\SourceInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Abstract factory implementation used in the default CreateProcessFactory,
+ * but can be used as a base for custom factory implementation.
+ */
+abstract class AbstractCreateProcessFactory implements CreateProcessFactoryInterface
+{
+    public function get(Creator $creator, ?LoggerInterface $logger = null): CreateProcess
+    {
+        $tsk = GeneralUtility::makeInstance(CreateProcess::class);
+        if ($logger instanceof LoggerInterface) {
+            $tsk->setLogger($logger);
+        }
+        $tsk->setTask($creator);
+        $tsk->setTemplateKey($creator->getBase());
+        /** @var class-string $processInterface */
+        $processInterface              = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['Sudhaus7Wizard']['registeredTemplateExtentions'][ $tsk->getTemplateKey() ];
+        /** @var WizardProcessInterface $wizardProcess */
+        $wizardProcess = GeneralUtility::makeInstance($processInterface);
+        $tsk->setTemplate($wizardProcess);
+        $sourceClassName = $creator->getSourceclass();
+        if (\class_exists($sourceClassName)) {
+            $sourceClass = GeneralUtility::makeInstance(ltrim($sourceClassName, '\\'));
+            $tsk->setSource($sourceClass instanceof SourceInterface ? $sourceClass : GeneralUtility::makeInstance(LocalDatabase::class));
+            $tsk->getSource()->setCreator($creator);
+            $tsk->getSource()->setLogger($logger);
+        }
+        $pid = $creator->getSourcepid();
+        $tsk->setSiteConfig($tsk->getSource()->getSiteConfig($pid));
+        return $tsk;
+    }
+}

--- a/Classes/Services/CreateProcessFactory.php
+++ b/Classes/Services/CreateProcessFactory.php
@@ -15,47 +15,12 @@ declare(strict_types=1);
 
 namespace SUDHAUS7\Sudhaus7Wizard\Services;
 
-use Psr\Log\LoggerInterface;
-use SUDHAUS7\Sudhaus7Wizard\CreateProcess;
-use SUDHAUS7\Sudhaus7Wizard\Domain\Model\Creator;
-use SUDHAUS7\Sudhaus7Wizard\Interfaces\WizardProcessInterface;
-use SUDHAUS7\Sudhaus7Wizard\Sources\LocalDatabase;
-use SUDHAUS7\Sudhaus7Wizard\Sources\SourceInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-
 /**
- * @internal
+ * Default factory implementation to retrieve a `CreateProcess` instance
+ * based on the passed `Creator` dataset.
+ *
+ * @internal not part of public API.
  */
-final class CreateProcessFactory
+final class CreateProcessFactory extends AbstractCreateProcessFactory
 {
-    /**
-     * @internal
-     * @param Creator $creator
-     * @param LoggerInterface|null $logger
-     * @return CreateProcess
-     */
-    public static function get(Creator $creator, ?LoggerInterface $logger = null): CreateProcess
-    {
-        $tsk              = GeneralUtility::makeInstance(CreateProcess::class);
-        if ($logger instanceof LoggerInterface) {
-            $tsk->setLogger($logger);
-        }
-        $tsk->setTask($creator);
-        $tsk->setTemplateKey($creator->getBase());
-        /** @var class-string $processInterface */
-        $processInterface              = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['Sudhaus7Wizard']['registeredTemplateExtentions'][ $tsk->getTemplateKey() ];
-        /** @var WizardProcessInterface $wizardProcess */
-        $wizardProcess = GeneralUtility::makeInstance($processInterface);
-        $tsk->setTemplate($wizardProcess);
-        $sourceClassName = $creator->getSourceclass();
-        if (\class_exists($sourceClassName)) {
-            $sourceClass = GeneralUtility::makeInstance(ltrim($sourceClassName, '\\'));
-            $tsk->setSource($sourceClass instanceof SourceInterface ? $sourceClass : GeneralUtility::makeInstance(LocalDatabase::class));
-            $tsk->getSource()->setCreator($creator);
-            $tsk->getSource()->setLogger($logger);
-        }
-        $pid = $creator->getSourcepid();
-        $tsk->setSiteConfig($tsk->getSource()->getSiteConfig($pid));
-        return $tsk;
-    }
 }

--- a/Classes/Services/CreateProcessFactoryInterface.php
+++ b/Classes/Services/CreateProcessFactoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * @author Frank Berger <fberger@sudhaus7.de>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace SUDHAUS7\Sudhaus7Wizard\Services;
+
+use Psr\Log\LoggerInterface;
+use SUDHAUS7\Sudhaus7Wizard\CreateProcess;
+use SUDHAUS7\Sudhaus7Wizard\Domain\Model\Creator;
+
+/**
+ * Factory interface for `CreateProcess` instantiation.
+ */
+interface CreateProcessFactoryInterface
+{
+    /**
+     * Factory method to build a `CreateProcess` instance based on the `Creator` dataset.
+     *
+     * @param Creator $creator
+     * @param LoggerInterface|null $logger
+     * @return CreateProcess
+     */
+    public function get(Creator $creator, ?LoggerInterface $logger = null): CreateProcess;
+}

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -21,6 +21,8 @@ use SUDHAUS7\Sudhaus7Wizard\EventHandlers\FinalTTContentFormFrameworkListener;
 use SUDHAUS7\Sudhaus7Wizard\EventHandlers\PreSysFileReferenceEventHandler;
 use SUDHAUS7\Sudhaus7Wizard\EventHandlers\SysFileReferenceHandleLinkFieldListener;
 use SUDHAUS7\Sudhaus7Wizard\EventHandlers\TypoLinkinRichTextFieldsEvent;
+use SUDHAUS7\Sudhaus7Wizard\Services\CreateProcessFactory;
+use SUDHAUS7\Sudhaus7Wizard\Services\CreateProcessFactoryInterface;
 use SUDHAUS7\Sudhaus7Wizard\Sources\LocalDatabase;
 use SUDHAUS7\Sudhaus7Wizard\Sources\SourceInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -29,6 +31,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void {
     $services = $containerConfigurator->services();
     $services->defaults()
+             // @todo public as default is a bad practice - change this and declare only required services public.
              ->public()
              ->autowire()
              ->autoconfigure();
@@ -40,6 +43,7 @@ return static function (ContainerConfigurator $containerConfigurator, ContainerB
                  __DIR__ . '/../Classes/Backend/',
              ]);
 
+    $services->alias(CreateProcessFactoryInterface::class, CreateProcessFactory::class);
     $services->alias(SourceInterface::class, LocalDatabase::class);
     $services->set(RunCommand::class)
         ->tag('console.command', [


### PR DESCRIPTION
Basically, there are different ways to implement class
factories. Using a `final` class with a static method
without a interface on the factory class or the class
to be created by the factory is considerable bad and
prevents proper exchanging things.

A industry wide approach for providing good and exchangable
factories is following way:

* Build upon a factory class interface, ex. `MyFactoryInterface`
* Providing a abstract factory class implementing the interface
  and the default behaviour, ex. `AbstractFactory`
* Provide a slim class implementation based on the `AbstractFactory`,
  `MyFactory extends AbstractFactory`
* Add a DI configuration to retrieve the `MyFactory` based on the
  `MyFactoryInterface`.
* Use DI in code places to retrieve the factory based on the interface
  and operate with this.

To comply with this approach, this change ...

* adds a `CreateProcessFactoryInterface` with a non-static
  `get()` method.
* provide a abstract `AbstractCreateProcessFactory` class and
  move the code from the current `CreateProcessFactory` to the
  abstract implementation.
* Remove the method from the `CreateProcessFactory` and extend
  directly from the `AbstractCreateProcessFactory`
* Use the interface to retrieve the wanted factory implementation
  where the factory is required to retrieve the `CreateProcess`
  instance.

That allows consumer extension to create easier test mocks and
more important influence the instanciating in a variaty of ways.

Note: This is a more conveniant approach than adding a couple
      of limiting events to the factory class itself.

The adjusted DI approach for the factory class is marked as
internal and not considered as public api and can change at
any point in time.

Resolves: #9
